### PR TITLE
Fix support for UZH mensas

### DIFF
--- a/internal/uzh/provider.go
+++ b/internal/uzh/provider.go
@@ -190,6 +190,10 @@ func (p *Provider) FetchCanteens(ctx context.Context, lang string) ([]base.Cante
 	}
 
 	result := make([]base.CanteenMetadata, 0, len(canteenMap))
+	for _, meta := range canteenMap {
+		result = append(result, meta)
+	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
This fixes support for UZH canteens which seems to have been broken by commit 2f24fef70c70cc2af4e7f4e2be9ba426857dafe6.